### PR TITLE
Don't deliver responses out of band

### DIFF
--- a/Sources/JSONRPC/ProtocolTransport.swift
+++ b/Sources/JSONRPC/ProtocolTransport.swift
@@ -253,14 +253,12 @@ extension ProtocolTransport {
         case .failure(let error):
             responseHandler(.failure(error))
         case .success(let data):
-            queue.async {
-                do {
-                    let jsonResult = try self.decoder.decode(JSONRPCResponse<T>.self, from: data)
+            do {
+                let jsonResult = try self.decoder.decode(JSONRPCResponse<T>.self, from: data)
 
-                    responseHandler(.success(jsonResult))
-                } catch {
-                    responseHandler(.failure(error))
-                }
+                responseHandler(.success(jsonResult))
+            } catch {
+                responseHandler(.failure(error))
             }
         }
     }


### PR DESCRIPTION
Great library, thanks! I'd like to suggest this improvement:

> This change ensures that responses and notifications are dispatched in the order they are received with respect to each other. This is important especially for pubsub, where the response to the initial subscription request carries the subscription ID, knowledge of which is required to dispatch later subscription updates to the correct recipient.

