### PR TITLE
Implement `JSONValue` Decoder

### DIFF
--- a/Sources/JSONRPC/JSONValueDecoder.swift
+++ b/Sources/JSONRPC/JSONValueDecoder.swift
@@ -1,0 +1,350 @@
+import Foundation
+import Combine
+
+/// An object that decodes instances of a data type from `JSONValue` objects.
+public class JSONValueDecoder: TopLevelDecoder {
+    public typealias Input = JSONValue
+
+    public init() {
+        // Do nothing, this definition here just to bump constructor visibility
+    }
+
+    /// Returns a value of the type you specify, decoded from a `JSONValue` object.
+    public func decode<T>(
+        _ type: T.Type,
+        from: JSONValueDecoder.Input
+    ) throws -> T where T: Decodable {
+        return try T(from: JSONValueDecoderImpl(referencing: from))
+    }
+}
+
+internal struct JSONKey: CodingKey {
+    public var stringValue: String
+    public var intValue: Int?
+
+    public init(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    public init(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+
+    internal static let `super` = JSONKey(stringValue: "super")
+}
+
+internal class JSONUnkeyedContainer: UnkeyedDecodingContainer {
+    private let decoder: JSONValueDecoderImpl
+    private let container: [JSONValue]
+    private(set) public var currentIndex: Int = 0
+
+    internal init(referencing decoder: JSONValueDecoderImpl, wrapping container: [JSONValue]) {
+        self.decoder = decoder
+        self.container = container
+    }
+
+    public var codingPath: [CodingKey] {
+        return decoder.codingPath
+    }
+
+    public var count: Int? {
+        return container.count
+    }
+
+    public var isAtEnd: Bool {
+        return currentIndex >= container.count
+    }
+
+    private func withNextValue<T>(result: (_ value: JSONValue) throws -> T) throws -> T {
+        decoder.codingPath.append(JSONKey(intValue: self.currentIndex))
+        defer { decoder.codingPath.removeLast() }
+
+        if isAtEnd {
+            throw DecodingError.valueNotFound(
+                JSONValue?.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Array exhausted."
+                )
+            )
+        }
+
+        let value = container[currentIndex]
+        currentIndex += 1
+
+        return try result(value)
+    }
+
+    func decodeNil() throws -> Bool {
+        return try withNextValue { value in return value == .null }
+    }
+
+    func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+        return try withNextValue { value in
+            return try decoder.nested(for: value).singleValueContainer().decode(type)
+        }
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws ->
+            KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+        return try withNextValue { value in
+            return try decoder.nested(for: value).container(keyedBy: type)
+        }
+    }
+
+    func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        return try withNextValue { value in
+            return try decoder.nested(for: value).unkeyedContainer()
+        }
+    }
+
+    func superDecoder() throws -> Decoder {
+        throw DecodingError.valueNotFound(
+            JSONValue?.self,
+            DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "Super not supported for arrays."
+            )
+        )
+    }
+}
+
+internal class JSONKeyedContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
+    typealias Key = K
+
+    let decoder: JSONValueDecoderImpl
+    let container: [String: JSONValue]
+
+    internal init(referencing decoder: JSONValueDecoderImpl,
+                  wrapping container: [String: JSONValue]) {
+        self.decoder = decoder
+        self.container = container
+    }
+
+    public var codingPath: [CodingKey] {
+        return decoder.codingPath
+    }
+
+    public var allKeys: [Key] {
+        return container.keys.compactMap { Key(stringValue: $0) }
+    }
+
+    func contains(_ key: Key) -> Bool {
+        return container[key.stringValue] != nil
+    }
+
+    func decodeNil(forKey key: Key) throws -> Bool {
+        if let entry = container[key.stringValue] {
+            return entry == .null
+        } else {
+            return true
+        }
+    }
+
+    private func withValue<T>(forKey key: CodingKey,
+                              result: (_ entry: JSONValue) throws -> T) throws -> T {
+        guard let value = container[key.stringValue] else {
+            throw DecodingError.keyNotFound(
+                key,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")"
+                )
+            )
+        }
+
+        decoder.codingPath.append(key)
+        defer { decoder.codingPath.removeLast() }
+
+        return try result(value)
+    }
+
+    func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T: Decodable {
+        try withValue(forKey: key) { value in
+            return try decoder.nested(for: value).singleValueContainer().decode(type)
+        }
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key)
+            throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+        try withValue(forKey: key) { value in
+            return try decoder.nested(for: value).container(keyedBy: type)
+        }
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+        try withValue(forKey: key) { value in
+            return try decoder.nested(for: value).unkeyedContainer()
+        }
+    }
+
+    public func superDecoder() throws -> Decoder {
+        try withValue(forKey: JSONKey.super) { value in decoder.nested(for: value) }
+    }
+
+    public func superDecoder(forKey key: Key) throws -> Decoder {
+        try withValue(forKey: key) { value in decoder.nested(for: value) }
+    }
+}
+
+internal class JSONValueDecoderImpl: Decoder, SingleValueDecodingContainer {
+    internal(set) public var codingPath: [CodingKey]
+    public var userInfo: [CodingUserInfoKey: Any] = [:]
+    private let value: JSONValue
+
+    init(referencing value: JSONValue, at codingPath: [CodingKey] = []) {
+        self.value = value
+        self.codingPath = codingPath
+    }
+
+    internal func nested(for value: JSONValue) -> JSONValueDecoderImpl {
+        return JSONValueDecoderImpl(referencing: value, at: codingPath)
+    }
+
+    private func unsatisfiedType(_ type: Any.Type) throws -> Never {
+        throw DecodingError.typeMismatch(
+            type,
+            DecodingError.Context(
+                codingPath: codingPath,
+                debugDescription: "\(String(describing: value)) not a \(type)",
+                underlyingError: nil
+            )
+        )
+    }
+
+    private func inconvertibleType(_ type: Any.Type) throws -> Never {
+        throw DecodingError.typeMismatch(
+            type,
+            DecodingError.Context(
+                codingPath: codingPath,
+                debugDescription: "\(String(describing: value)) cannot be converted to \(type)",
+                underlyingError: nil
+            )
+        )
+    }
+
+    public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key>
+            where Key: CodingKey {
+        if case let .hash(dictionary) = value {
+            return KeyedDecodingContainer(JSONKeyedContainer<Key>(referencing: self, wrapping: dictionary))
+        } else {
+            throw DecodingError.typeMismatch(
+                [String: Any].self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "\(String(describing: value)) not a container",
+                    underlyingError: nil
+                )
+            )
+        }
+    }
+
+    public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        if case let .array(array) = value {
+            return JSONUnkeyedContainer(referencing: self, wrapping: array)
+        } else {
+            throw DecodingError.typeMismatch(
+                [String: Any].self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "\(String(describing: value)) not a container",
+                    underlyingError: nil
+                )
+            )
+        }
+    }
+
+    public func singleValueContainer() throws -> SingleValueDecodingContainer {
+        self
+    }
+
+    func decodeNil() -> Bool {
+        return self.value == .null
+    }
+
+    func decode(_ type: Bool.Type) throws -> Bool {
+        guard case let .bool(value) = self.value else { try unsatisfiedType(type) }
+        return value
+    }
+
+    func decode(_ type: String.Type) throws -> String {
+        guard case let .string(value) = self.value else { try unsatisfiedType(type) }
+        return value
+    }
+
+    func decode(_ type: Double.Type) throws -> Double {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        return value
+    }
+
+    func decode(_ type: Float.Type) throws -> Float {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        return Float(value)
+    }
+
+    func decode(_ type: Int.Type) throws -> Int {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        guard let value = Int(exactly: value) else { try inconvertibleType(type) }
+        return value
+    }
+
+    func decode(_ type: Int8.Type) throws -> Int8 {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        guard let value = Int8(exactly: value) else { try inconvertibleType(type) }
+        return value
+    }
+
+    func decode(_ type: Int16.Type) throws -> Int16 {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        guard let value = Int16(exactly: value) else { try inconvertibleType(type) }
+        return value
+    }
+
+    func decode(_ type: Int32.Type) throws -> Int32 {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        guard let value = Int32(exactly: value) else { try inconvertibleType(type) }
+        return value
+    }
+
+    func decode(_ type: Int64.Type) throws -> Int64 {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        guard let value = Int64(exactly: value) else { try inconvertibleType(type) }
+        return value
+    }
+
+    func decode(_ type: UInt.Type) throws -> UInt {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        guard let value = UInt(exactly: value) else { try inconvertibleType(type) }
+        return value
+    }
+
+    func decode(_ type: UInt8.Type) throws -> UInt8 {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        guard let value = UInt8(exactly: value) else { try inconvertibleType(type) }
+        return value
+    }
+
+    func decode(_ type: UInt16.Type) throws -> UInt16 {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        guard let value = UInt16(exactly: value) else { try inconvertibleType(type) }
+        return value
+    }
+
+    func decode(_ type: UInt32.Type) throws -> UInt32 {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        guard let value = UInt32(exactly: value) else { try inconvertibleType(type) }
+        return value
+    }
+
+    func decode(_ type: UInt64.Type) throws -> UInt64 {
+        guard case let .number(value) = self.value else { try unsatisfiedType(type) }
+        guard let value = UInt64(exactly: value) else { try inconvertibleType(type) }
+        return value
+    }
+
+    func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+        return try T(from: self)
+    }
+}

--- a/Sources/JSONRPC/JSONValueDecoder.swift
+++ b/Sources/JSONRPC/JSONValueDecoder.swift
@@ -215,11 +215,10 @@ internal class JSONValueDecoderImpl: Decoder, SingleValueDecodingContainer {
     }
 
     private func inconvertibleType(_ type: Any.Type) throws -> Never {
-        throw DecodingError.typeMismatch(
-            type,
+        throw DecodingError.dataCorrupted(
             DecodingError.Context(
                 codingPath: codingPath,
-                debugDescription: "\(String(describing: value)) cannot be converted to \(type)",
+                debugDescription: "\(String(describing: value)) does not fit in a \(type)",
                 underlyingError: nil
             )
         )
@@ -281,7 +280,9 @@ internal class JSONValueDecoderImpl: Decoder, SingleValueDecodingContainer {
 
     func decode(_ type: Float.Type) throws -> Float {
         guard case let .number(value) = self.value else { try unsatisfiedType(type) }
-        return Float(value)
+        let floatValue = Float(value)
+        if value.isFinite && floatValue.isInfinite { try inconvertibleType(type) }
+        return floatValue
     }
 
     func decode(_ type: Int.Type) throws -> Int {

--- a/Sources/JSONRPC/JSONValueDecoder.swift
+++ b/Sources/JSONRPC/JSONValueDecoder.swift
@@ -234,7 +234,7 @@ internal class JSONValueDecoderImpl: Decoder, SingleValueDecodingContainer {
                 [String: Any].self,
                 DecodingError.Context(
                     codingPath: codingPath,
-                    debugDescription: "\(String(describing: value)) not a container",
+                    debugDescription: "\(String(describing: value)) not a hash",
                     underlyingError: nil
                 )
             )
@@ -249,7 +249,7 @@ internal class JSONValueDecoderImpl: Decoder, SingleValueDecodingContainer {
                 [String: Any].self,
                 DecodingError.Context(
                     codingPath: codingPath,
-                    debugDescription: "\(String(describing: value)) not a container",
+                    debugDescription: "\(String(describing: value)) not an array",
                     underlyingError: nil
                 )
             )

--- a/Sources/JSONRPC/JSONValueDecoder.swift
+++ b/Sources/JSONRPC/JSONValueDecoder.swift
@@ -18,42 +18,42 @@ public class JSONValueDecoder: TopLevelDecoder {
     }
 }
 
-internal struct JSONKey: CodingKey {
-    public var stringValue: String
-    public var intValue: Int?
+fileprivate struct JSONKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
 
-    public init(stringValue: String) {
+    init(stringValue: String) {
         self.stringValue = stringValue
         self.intValue = nil
     }
 
-    public init(intValue: Int) {
+    init(intValue: Int) {
         self.stringValue = "\(intValue)"
         self.intValue = intValue
     }
 
-    internal static let `super` = JSONKey(stringValue: "super")
+    static let `super` = JSONKey(stringValue: "super")
 }
 
-internal class JSONUnkeyedContainer: UnkeyedDecodingContainer {
+fileprivate class JSONUnkeyedContainer: UnkeyedDecodingContainer {
     private let decoder: JSONValueDecoderImpl
     private let container: [JSONValue]
-    private(set) public var currentIndex: Int = 0
+    private(set) var currentIndex: Int = 0
 
     internal init(referencing decoder: JSONValueDecoderImpl, wrapping container: [JSONValue]) {
         self.decoder = decoder
         self.container = container
     }
 
-    public var codingPath: [CodingKey] {
+    var codingPath: [CodingKey] {
         return decoder.codingPath
     }
 
-    public var count: Int? {
+    var count: Int? {
         return container.count
     }
 
-    public var isAtEnd: Bool {
+    var isAtEnd: Bool {
         return currentIndex >= container.count
     }
 
@@ -111,7 +111,7 @@ internal class JSONUnkeyedContainer: UnkeyedDecodingContainer {
     }
 }
 
-internal class JSONKeyedContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
+fileprivate class JSONKeyedContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
     typealias Key = K
 
     let decoder: JSONValueDecoderImpl
@@ -123,11 +123,11 @@ internal class JSONKeyedContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
         self.container = container
     }
 
-    public var codingPath: [CodingKey] {
+    var codingPath: [CodingKey] {
         return decoder.codingPath
     }
 
-    public var allKeys: [Key] {
+    var allKeys: [Key] {
         return container.keys.compactMap { Key(stringValue: $0) }
     }
 
@@ -180,18 +180,18 @@ internal class JSONKeyedContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
         }
     }
 
-    public func superDecoder() throws -> Decoder {
+    func superDecoder() throws -> Decoder {
         try withValue(forKey: JSONKey.super) { value in decoder.nested(for: value) }
     }
 
-    public func superDecoder(forKey key: Key) throws -> Decoder {
+    func superDecoder(forKey key: Key) throws -> Decoder {
         try withValue(forKey: key) { value in decoder.nested(for: value) }
     }
 }
 
-internal class JSONValueDecoderImpl: Decoder, SingleValueDecodingContainer {
-    internal(set) public var codingPath: [CodingKey]
-    public var userInfo: [CodingUserInfoKey: Any] = [:]
+fileprivate class JSONValueDecoderImpl: Decoder, SingleValueDecodingContainer {
+    var codingPath: [CodingKey]
+    var userInfo: [CodingUserInfoKey: Any] = [:]
     private let value: JSONValue
 
     init(referencing value: JSONValue, at codingPath: [CodingKey] = []) {
@@ -224,7 +224,7 @@ internal class JSONValueDecoderImpl: Decoder, SingleValueDecodingContainer {
         )
     }
 
-    public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key>
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key>
             where Key: CodingKey {
         if case let .hash(dictionary) = value {
             return KeyedDecodingContainer(JSONKeyedContainer<Key>(referencing: self, wrapping: dictionary))
@@ -240,7 +240,7 @@ internal class JSONValueDecoderImpl: Decoder, SingleValueDecodingContainer {
         }
     }
 
-    public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
         if case let .array(array) = value {
             return JSONUnkeyedContainer(referencing: self, wrapping: array)
         } else {
@@ -255,7 +255,7 @@ internal class JSONValueDecoderImpl: Decoder, SingleValueDecodingContainer {
         }
     }
 
-    public func singleValueContainer() throws -> SingleValueDecodingContainer {
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
         self
     }
 

--- a/Tests/JSONRPCTests/JSONValueDecoderTests.swift
+++ b/Tests/JSONRPCTests/JSONValueDecoderTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+import JSONRPC
+
+final class JSONValueDecoderTests: XCTestCase {
+    struct SimpleStruct: Decodable, Equatable {
+        var bool: Bool?
+        var string: String?
+        var double: Double?
+        var float: Float?
+        var int: Int?
+        var int8: Int8?
+        var int16: Int16?
+        var int32: Int32?
+        var int64: Int64?
+        var uint: UInt?
+        var uint8: UInt8?
+        var uint16: UInt16?
+        var uint32: UInt32?
+        var uint64: UInt64?
+
+        var any: JSONValue?
+        var intArray: [Int]?
+
+        var nested: [SimpleStruct]?
+    }
+
+    func testDecode() throws {
+        XCTAssertEqual(
+            try JSONValueDecoder().decode(
+                SimpleStruct.self,
+                from: [
+                    "bool": true,
+                    "string": "foo",
+                    "double": 101,
+                    "float": 102,
+                    "int": 103,
+                    "int8": 104,
+                    "int16": 105,
+                    "int32": 106,
+                    "int64": 107,
+                    "uint": 108,
+                    "uint8": 109,
+                    "uint16": 110,
+                    "uint32": 111,
+                    "uint64": 112,
+
+                    "any": "bar",
+                    "intArray": [11, 22, 33],
+
+                    "nested": [["int": 11], ["int": 22]]
+                ]
+            ),
+            SimpleStruct(
+                bool: true,
+                string: "foo",
+                double: 101,
+                float: 102,
+                int: 103,
+                int8: 104,
+                int16: 105,
+                int32: 106,
+                int64: 107,
+                uint: 108,
+                uint8: 109,
+                uint16: 110,
+                uint32: 111,
+                uint64: 112,
+
+                any: JSONValue.string("bar"),
+                intArray: [11, 22, 33],
+                nested: [SimpleStruct(int: 11), SimpleStruct(int: 22)]
+            )
+        )
+    }
+
+    func testDecodeUnkeyedErrorPath() throws {
+        XCTAssertThrowsError(
+            try JSONValueDecoder().decode(
+                SimpleStruct.self,
+                from: JSONValue.hash(["intArray": .array([.number(0),
+                                                          .number(1),
+                                                          .bool(false)])])
+            )
+        ) { error in
+            guard case let DecodingError.typeMismatch(_, context) = error else {
+                XCTFail("Expected typError")
+                return
+            }
+            XCTAssertEqual(
+                context.codingPath.count,
+                2
+            )
+            XCTAssertEqual(
+                context.codingPath[0].stringValue,
+                "intArray"
+            )
+            XCTAssertEqual(
+                context.codingPath[1].intValue,
+                2
+            )
+        }
+    }
+
+    func testDecodeNotDouble() throws {
+        XCTAssertThrowsError(
+            try JSONValueDecoder().decode(
+                SimpleStruct.self,
+                from: JSONValue.hash(["double": "string"])
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "The data couldn’t be read because it isn’t in the correct format."
+            )
+        }
+    }
+
+    func testDecodeOverflow() throws {
+        XCTAssertThrowsError(
+            try JSONValueDecoder().decode(
+                SimpleStruct.self,
+                from: JSONValue.hash(["int8": "1000"])
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "The data couldn’t be read because it isn’t in the correct format."
+            )
+        }
+    }
+}

--- a/Tests/JSONRPCTests/JSONValueDecoderTests.swift
+++ b/Tests/JSONRPCTests/JSONValueDecoderTests.swift
@@ -83,7 +83,7 @@ final class JSONValueDecoderTests: XCTestCase {
             )
         ) { error in
             guard case let DecodingError.typeMismatch(_, context) = error else {
-                XCTFail("Expected typError")
+                XCTFail("Expected typeError")
                 return
             }
             XCTAssertEqual(

--- a/Tests/JSONRPCTests/JSONValueDecoderTests.swift
+++ b/Tests/JSONRPCTests/JSONValueDecoderTests.swift
@@ -119,7 +119,21 @@ final class JSONValueDecoderTests: XCTestCase {
         XCTAssertThrowsError(
             try JSONValueDecoder().decode(
                 SimpleStruct.self,
-                from: JSONValue.hash(["int8": "1000"])
+                from: JSONValue.hash(["int8": 300])
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "The data couldn’t be read because it isn’t in the correct format."
+            )
+        }
+    }
+
+    func testDecodeFloatOverflow() throws {
+        XCTAssertThrowsError(
+            try JSONValueDecoder().decode(
+                SimpleStruct.self,
+                from: JSONValue.hash(["float": 1e300])
             )
         ) { error in
             XCTAssertEqual(


### PR DESCRIPTION
Here is a new feature that allows decoding a `JSONValue` into a `Decodable`.

Its primary purpose is to allow casting an `AnyJSONRPCNotification`, or its payload, into a more specific type. This is useful when a type can be derived from partial notification data. For example, the notification might be a subscription update containing a subscription ID, which can be used to look up the expected payload type.

There might be other use cases as well, for instance polymorphic responses.

Decoding JSON first to `JSONValue`, then from `JSONValue` to the final type is somewhat inefficient compared to directly decoding to the target type. However, direct decoding can be relatively complicated depending on the use case and sacrifices flexibility. Since JSON-RPC already isn't the most efficient RPC format out there I think it's a trade-off worth making, what do you think?
