### PR TITLE
Make it work on Linux

### DIFF
--- a/Sources/JSONRPC/JSONValueDecoder.swift
+++ b/Sources/JSONRPC/JSONValueDecoder.swift
@@ -1,5 +1,16 @@
 import Foundation
-import Combine
+#if canImport(Combine)
+    import Combine
+#else
+    public protocol TopLevelDecoder {
+        associatedtype Input
+
+        func decode<T>(
+            _ type: T.Type,
+            from: JSONValueDecoder.Input
+        ) throws -> T where T: Decodable
+    }
+#endif
 
 /// An object that decodes instances of a data type from `JSONValue` objects.
 public class JSONValueDecoder: TopLevelDecoder {

--- a/Tests/JSONRPCTests/JSONValueDecoderTests.swift
+++ b/Tests/JSONRPCTests/JSONValueDecoderTests.swift
@@ -108,10 +108,17 @@ final class JSONValueDecoderTests: XCTestCase {
                 from: JSONValue.hash(["double": "string"])
             )
         ) { error in
-            XCTAssertEqual(
-                error.localizedDescription,
-                "The data couldn’t be read because it isn’t in the correct format."
-            )
+        	#if os(Linux)
+                        XCTAssertEqual(
+		            error.localizedDescription,
+		            "The operation could not be completed. The data isn’t in the correct format."
+		        )
+        	#else
+		        XCTAssertEqual(
+		            error.localizedDescription,
+		            "The data couldn’t be read because it isn’t in the correct format."
+		        )
+            #endif
         }
     }
 
@@ -122,10 +129,17 @@ final class JSONValueDecoderTests: XCTestCase {
                 from: JSONValue.hash(["int8": 300])
             )
         ) { error in
-            XCTAssertEqual(
-                error.localizedDescription,
-                "The data couldn’t be read because it isn’t in the correct format."
-            )
+        	#if os(Linux)
+                        XCTAssertEqual(
+		            error.localizedDescription,
+		            "The operation could not be completed. The data isn’t in the correct format."
+		        )
+        	#else
+		        XCTAssertEqual(
+		            error.localizedDescription,
+		            "The data couldn’t be read because it isn’t in the correct format."
+		        )
+            #endif
         }
     }
 
@@ -136,10 +150,17 @@ final class JSONValueDecoderTests: XCTestCase {
                 from: JSONValue.hash(["float": 1e300])
             )
         ) { error in
-            XCTAssertEqual(
-                error.localizedDescription,
-                "The data couldn’t be read because it isn’t in the correct format."
-            )
+        	#if os(Linux)
+                        XCTAssertEqual(
+		            error.localizedDescription,
+		            "The operation could not be completed. The data isn’t in the correct format."
+		        )
+        	#else
+		        XCTAssertEqual(
+		            error.localizedDescription,
+		            "The data couldn’t be read because it isn’t in the correct format."
+		        )
+            #endif
         }
     }
 }

--- a/Tests/JSONRPCTests/ProtocolTransportTests.swift
+++ b/Tests/JSONRPCTests/ProtocolTransportTests.swift
@@ -79,7 +79,7 @@ final class ProtocolTransportTests: XCTestCase {
         let result = JSONRPCNotification(method: "mynotification", params: params)
         let resultData = try JSONEncoder().encode(result)
 
-        XCTAssertEqual(dataTransport.writtenData, [resultData])
+        assertDataArraysEquals(dataTransport.writtenData, [resultData])
     }
 
 	@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -94,7 +94,16 @@ final class ProtocolTransportTests: XCTestCase {
 		let result = JSONRPCNotification(method: "mynotification", params: params)
 		let resultData = try JSONEncoder().encode(result)
 
-		XCTAssertEqual(dataTransport.writtenData, [resultData])
+		assertDataArraysEquals(dataTransport.writtenData, [resultData])
+	}
+
+	func assertDataArraysEquals(_ expr1: [Data], _ expr2: [Data]) {
+		XCTAssertEqual(expr1.count, expr2.count)
+		for idx in 0..<expr1.count {
+			let sorted1 = expr1[idx].sorted()
+			let sorted2 = expr2[idx].sorted()
+			XCTAssertEqual(sorted1, sorted2)
+		}
 	}
 
     func testServerToClientNotification() throws {


### PR DESCRIPTION
While attempting to use LanguageClient on Linux, this dependency failed to compile due to the use of the Combine framework.

<sub>I would send PRs for all dependencies of LanguageClient if you want them, so they compile/work on Linux, if this is wished</sub>