### PR TITLE
Add WebSocket DataChannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The closures on the `DataChannel` allow different transport mechanisms to be use
   - Using swift actors to pass messages.
   - Can eg be useful for testing, where both client and server are implemented in swift and running in the same process.
   - Usage: `let (clientChannel, serverChannel) = DataChannel.withDataActor()`
+- WebSocket channel
+  - Uses `URLSessionWebSocketTask` as a message transport.
+  - Usage: `let chanell = DataChannel.webSocket(url: socketURL, terminationHandler: { print("socket closed" })`
 
 ## Contributing and Collaboration
 

--- a/Sources/JSONRPC/DataChannel+WebSocket.swift
+++ b/Sources/JSONRPC/DataChannel+WebSocket.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+#if !os(Linux)
 extension DataChannel {
     /// A channel that facilitates communication over WebSockets.
     public static func webSocket(
@@ -42,3 +43,4 @@ extension DataChannel {
         return DataChannel(writeHandler: writeHandler, dataSequence: stream)
     }
 }
+#endif

--- a/Sources/JSONRPC/DataChannel+WebSocket.swift
+++ b/Sources/JSONRPC/DataChannel+WebSocket.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+extension DataChannel {
+    /// A channel that facilitates communication over WebSockets.
+    public static func webSocket(
+        url: URL,
+        terminationHandler: @escaping @Sendable () -> Void
+    ) throws -> DataChannel {
+        let socketSession: URLSession = .init(configuration: .default)
+        let socket: URLSessionWebSocketTask = socketSession.webSocketTask(with: url)
+        
+        socket.resume()
+        
+        let (stream, continuation) = DataSequence.makeStream()
+
+        Task {
+            while socket.state == .running {
+                do {
+                    let message = try await socket.receive()
+                    switch message {
+                    case .data(let data):
+                        continuation.yield(data)
+                    case .string(let string):
+                        continuation.yield(Data(string.utf8))
+                    @unknown default:
+                        fatalError("Unhandled message type")
+                    }
+                } catch {
+                    if socket.state == .canceling {
+                        terminationHandler()
+                    }
+                    continuation.finish()
+                    throw error
+                }
+            }
+        }
+        
+        let writeHandler: DataChannel.WriteHandler = {
+            try await socket.send(.data($0))
+        }
+        
+        return DataChannel(writeHandler: writeHandler, dataSequence: stream)
+    }
+}


### PR DESCRIPTION
Adds a `DataChannel` for communicating via WebSockets. Supports a `terminationHandler` that allows you to restart a server when the socket closes unexpectedly.