### PR TITLE
Flush stdout buffer when writing data

### DIFF
--- a/Sources/JSONRPC/DataChannel+Stdio.swift
+++ b/Sources/JSONRPC/DataChannel+Stdio.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin.C
+#endif
 
 extension FileHandle {
 	public var dataStream: AsyncStream<Data> {
@@ -26,18 +31,15 @@ extension DataChannel {
 		stdio()
 	}
 
-	public static func stdio() -> DataChannel {
+	public static func stdio(flushWrites: Bool = true) -> DataChannel {
 
 		let writeHandler: DataChannel.WriteHandler = { data in
-			// Add a line break to flush the stdout buffer.
-			var data = data
-			data.append(contentsOf: lineBreak)
-
 			FileHandle.standardOutput.write(data)
+			if flushWrites {
+				fflush(stdout)
+			}
 		}
 
 		return DataChannel(writeHandler: writeHandler, dataSequence: FileHandle.standardInput.dataStream)
 	}
-
-	private static let lineBreak = [UInt8(ascii: "\n")]
 }

--- a/Sources/JSONRPC/DataChannel+Stdio.swift
+++ b/Sources/JSONRPC/DataChannel+Stdio.swift
@@ -21,12 +21,23 @@ extension FileHandle {
 }
 
 extension DataChannel {
+	@available(*, deprecated, renamed: "stdio", message: "Use stdio instead")
 	public static func stdioPipe() -> DataChannel {
+		stdio()
+	}
 
-		let writeHandler: DataChannel.WriteHandler = {
-			FileHandle.standardOutput.write($0)
+	public static func stdio() -> DataChannel {
+
+		let writeHandler: DataChannel.WriteHandler = { data in
+			// Add a line break to flush the stdout buffer.
+			var data = data
+			data.append(contentsOf: lineBreak)
+
+			FileHandle.standardOutput.write(data)
 		}
 
 		return DataChannel(writeHandler: writeHandler, dataSequence: FileHandle.standardInput.dataStream)
 	}
+
+	private static let lineBreak = [UInt8(ascii: "\n")]
 }


### PR DESCRIPTION
Flush stdout buffer when writing data. I noticed that without an extra line break, the receiver was not getting the message written to stdout.

As a nit (happy to revert) I thought that `stdio` was clearer that `stdioPipe` as afaik piping is specific to shell scripts, and stdin can be written to in other contexts.